### PR TITLE
Remove Uppercase(), this is not a valid address

### DIFF
--- a/src/lib/verify.js
+++ b/src/lib/verify.js
@@ -44,7 +44,7 @@ export const verify = token => {
     signatureParams.s
   );
   const addressBuffer = EthUtil.publicToAddress(publicKey);
-  const address = EthUtil.bufferToHex(addressBuffer).toUpperCase();
+  const address = EthUtil.bufferToHex(addressBuffer);
 
   const parsed_body = parseAsHeaders(body);
 


### PR DESCRIPTION
By uppercasing the address, the address becomes invalid.