### PR TITLE
Add example ACCOUNT_MNEMONIC in .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+ACCOUNT_MNEMONIC=abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
 CHAIN_PROVIDER_URL=https://bsc-dataseed.binance.org


### PR DESCRIPTION
This comes from a test case of the ethers.js project:

https://github.com/ethers-io/ethers.js/blob/ce8f1e4015c0f27bf178238770b1325136e3351a/packages/testcases/input/easyseed-bip39/bip39_vectors.en.json#L4

With this, users won't need to set their personal mnemonic or find a false one on their own.