### PR TITLE
Correct typo of params shorthand

### DIFF
--- a/src/lib/sign/sign.js
+++ b/src/lib/sign/sign.js
@@ -20,7 +20,7 @@ export const sign = async (signer, params = '1d') => {
 
   if(typeof params === 'string') {
     params = {
-      expire_in: params
+      expires_in: params
     }
   }
 


### PR DESCRIPTION
We have tried `sign(..., '14d')`  and it doesn't seem to work. Turn out, it is a typo when the params is a string.